### PR TITLE
Swap DEIMS variable 'label' for variable 'name' content for EML renderin...

### DIFF
--- a/modules/custom/deims_variable/deims_variable.field.inc
+++ b/modules/custom/deims_variable/deims_variable.field.inc
@@ -570,8 +570,8 @@ function deims_variable_field_formatter_view($entity_type, $entity, $field, $ins
 
       foreach ($items as $delta => $item) {
         $attribute = array();
-        $attribute['attributeName'] = $item['name'];
-        $attribute['attributeLabel'] = $item['label'];
+        $attribute['attributeName'] = $item['label'];
+        $attribute['attributeLabel'] = $item['name'];
         $attribute['attributeDefinition'] = $item['definition'];
 
         switch ($item['type']) {


### PR DESCRIPTION
...g

the DEIMS variable field "Name" is the most prominent (visible) attribute field in Drupal, and makes sense that is a human readable string.  The DEIMS variable field "Label" is the 'label' used in the header of the data source column/row, which may or may not be human readable.  However, EML in LTER is interpreted as <attributeName> being populated by the 'Label', and the <attributeLabel> being populated by the human readable DEIMS 'Name'.
