### PR TITLE
recovers the data set short name for EML rendering

### DIFF
--- a/modules/custom/eml/templates/eml--node--data-set.tpl.php
+++ b/modules/custom/eml/templates/eml--node--data-set.tpl.php
@@ -12,6 +12,12 @@
   <dataset>
     <title><?php print $label; ?></title>
 
+    <?php if (!empty($entity->field_short_name[LANGUAGE_NONE][0])): ?>
+      <shortname>
+         <?php print check_plain($entity->field_short_name[LANGUAGE_NONE][0]['value']); ?>
+      </shortname>
+    <?php endif; ?>
+
     <?php print render($content['field_person_creator']); ?>
 
     <?php print render($content['field_person_metadata_provider']); ?>


### PR DESCRIPTION
looks like I cannot use the print render($content['field_short_name'] cause somehow the EML view mode for the field is not assigned ( in manage display, shortname and pubDate, are in the 'disabled' area ).  I wonder how were not caught up by the module?
