### PR TITLE
refs #18357 - Move the download validation to happen before the batch process is called and don't remove the Download button.

### DIFF
--- a/modules/custom/deims_data_explorer/deims_data_explorer.pages.inc
+++ b/modules/custom/deims_data_explorer/deims_data_explorer.pages.inc
@@ -126,23 +126,29 @@ function deims_data_explorer_form($form, &$form_state, $variables, $connection, 
         break;
 
       case 'Download':
-        $file = file_save_data('', file_create_filename($connection['table'] . '.csv', variable_get('deims_data_explorer_dir', 'public://data-downloads/')));
+        // Add logic for download button disable and warning.
+        if (deims_data_explorer_get_row_count($connection, $filters) >= DEIMS_DOWNLOAD_COUNT) {
+          drupal_set_message('This is a very large data set. Please ' . l('contact us', 'contact') .
+            ' to obtain a copy.', 'warning', FALSE);
+        } else {
+          $file = file_save_data('', file_create_filename($connection['table'] . '.csv', variable_get('deims_data_explorer_dir', 'public://data-downloads/')));
 
-        // Set up the batch process.
-        $batch = array(
-          'title' => 'Processing Data Set',
-          'operations' => array(
-            array('_fetch_row_batch', array($query, $file)),
-            array('_process_file_for_download', array($file, $connection['table'], $form_state['values']['nid'])),
-          ),
-          'finished' => '_show_download_link',
-          'file' => drupal_get_path('module', 'deims_data_explorer') . '/deims_data_explorer.batch.inc'
-        );
+          // Set up the batch process.
+          $batch = array(
+            'title' => 'Processing Data Set',
+            'operations' => array(
+              array('_fetch_row_batch', array($query, $file)),
+              array('_process_file_for_download', array($file, $connection['table'], $form_state['values']['nid'])),
+            ),
+            'finished' => '_show_download_link',
+            'file' => drupal_get_path('module', 'deims_data_explorer') . '/deims_data_explorer.batch.inc'
+          );
 
-        batch_set($batch);
-        // This can be left blank because we're setting it in the finished
-        // callback hackery magic.
-        batch_process();
+          batch_set($batch);
+          // This can be left blank because we're setting it in the finished
+          // callback hackery magic.
+          batch_process();
+        }
         break;
 
       default:
@@ -225,12 +231,6 @@ function deims_data_explorer_form($form, &$form_state, $variables, $connection, 
     '#value' => 'Download',
   );
 
-  // Add logic for download button disable and warning.
-  if (deims_data_explorer_get_row_count($connection) >= DEIMS_DOWNLOAD_COUNT) {
-    drupal_set_message('This is a very large data set. Please ' . l('contact us', 'contact') .
-      ' to obtain a copy.', 'warning', FALSE);
-    unset($form['download']);
-  }
   return $form;
 }
 


### PR DESCRIPTION
The form submit processing logic should probably be factored out of the hook_form() and into a hook_form_submit(), but this will work for now and will not allow the batch process to begin if the resulting data set is larger than the limit defined.
