### PR TITLE
Follow-up to Chosen library fixes

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -38,11 +38,11 @@ projects[ctools][subdir] = "contrib"
 projects[context][version] = "3.0-beta6"
 projects[context][subdir] = "contrib"
 
-projects[chosen][version] = "2.0-beta2"
+projects[chosen][version] = "2.0-beta3"
 projects[chosen][subdir] = "contrib"
 ; Add support for the koenpunt fork of Chosen with supports adding options
 ; @see https://drupal.org/node/2012900
-projects[chosen][patch][] = "https://drupal.org/files/issues/2012900-chosen-select-or-other_0.patch"
+projects[chosen][patch][] = "https://drupal.org/files/issues/2012900-chosen-select-or-other_1.patch"
 
 projects[custom_breadcrumbs][version] = "2.0-alpha3"
 projects[custom_breadcrumbs][subdir] = "contrib"

--- a/modules/custom/deims_variable/deims_variable.field.inc
+++ b/modules/custom/deims_variable/deims_variable.field.inc
@@ -321,8 +321,8 @@ function deims_variable_field_widget_form(&$form, &$form_state, $field, $instanc
         '#required' => TRUE,
         '#attributes' => array(
           'data-create_option_text' => t('Use other unit'),
-          'class' => array('chosen-enabled'),
         ),
+        '#chosen' => TRUE,
       );
       $element['data']['maximum'] = array(
         '#type' => 'numberfield',

--- a/modules/features/deims_article/deims_article.features.field.inc
+++ b/modules/features/deims_article/deims_article.features.field.inc
@@ -329,7 +329,7 @@ function deims_article_field_default_fields() {
         'active' => 0,
         'module' => 'options',
         'settings' => array(
-          'apply_chosen' => 0,
+          'apply_chosen' => '',
           'autocomplete_path' => 'taxonomy/autocomplete',
           'size' => 60,
         ),
@@ -596,7 +596,7 @@ function deims_article_field_default_fields() {
         'active' => 1,
         'module' => 'options',
         'settings' => array(
-          'apply_chosen' => 0,
+          'apply_chosen' => '',
         ),
         'type' => 'options_select',
         'weight' => '1',

--- a/modules/features/deims_image_gallery/deims_image_gallery.features.field.inc
+++ b/modules/features/deims_image_gallery/deims_image_gallery.features.field.inc
@@ -250,7 +250,7 @@ function deims_image_gallery_field_default_fields() {
         'active' => 1,
         'module' => 'options',
         'settings' => array(
-          'apply_chosen' => 0,
+          'apply_chosen' => '',
         ),
         'type' => 'options_select',
         'weight' => '34',

--- a/modules/features/deims_person/deims_person.features.field.inc
+++ b/modules/features/deims_person/deims_person.features.field.inc
@@ -993,7 +993,7 @@ Prof.',
         'active' => 1,
         'module' => 'options',
         'settings' => array(
-          'apply_chosen' => 0,
+          'apply_chosen' => '',
         ),
         'type' => 'options_select',
         'weight' => '3',

--- a/modules/features/deims_project_role/deims_project_role.features.field.inc
+++ b/modules/features/deims_project_role/deims_project_role.features.field.inc
@@ -88,7 +88,7 @@ function deims_project_role_field_default_fields() {
         'active' => 1,
         'module' => 'options',
         'settings' => array(
-          'apply_chosen' => 0,
+          'apply_chosen' => '',
         ),
         'type' => 'options_select',
         'weight' => '2',


### PR DESCRIPTION
If you add a 'new' option inside the 'Unit of measure' field chosen widget, it does not auto-select the 'Other' option in the select list. I also fixed deims_variable.field.inc to use the #chosen FAPI property for that element instead of a class name, which is more reliable now.
