### PR TITLE
Fixes EML bug #70 introduced by schemaorg

### DIFF
--- a/modules/custom/eml/templates/eml--node--organization.tpl.php
+++ b/modules/custom/eml/templates/eml--node--organization.tpl.php
@@ -1,2 +1,2 @@
 <organizationName><?php print $label; ?></organizationName>
-<?php print render($content); ?>
+<?php print render($content['field_url']); ?>


### PR DESCRIPTION
this limits the content exposed in EMLs to the actual fields within the organization content type, avoiding accidental injection of schemaorg work
