### PR TITLE
Relaxes data explorer queries on text based fields

### DIFF
--- a/modules/custom/deims_data_explorer/deims_data_explorer.module
+++ b/modules/custom/deims_data_explorer/deims_data_explorer.module
@@ -302,7 +302,7 @@ function deims_data_explorer_filters_apply(QueryAlterableInterface $query, array
     switch ($filter['variable']['type']) {
       case '';
         if (drupal_strlen($filter['value'])) {
-          $query->condition($key, $filter['value']);
+          $query->condition($key, '%'.$filter['value'].'%', 'LIKE');
         }
         break;
 


### PR DESCRIPTION
Here is a fix for #75 - it adds the operator LIKE to the condition property of the query object for the DE, and surrounds the value of the string to match using the '%'.  Im not sure how this would playout with postgres, but works on mysql-mariadb.
