### PR TITLE
106 eml site details

### DIFF
--- a/modules/custom/eml/templates/eml--node--research-site.tpl.php
+++ b/modules/custom/eml/templates/eml--node--research-site.tpl.php
@@ -1,6 +1,7 @@
 <geographicCoverage>
   <geographicDescription>
     <?php print render($content['field_description']); ?>
+    <?php print render($content['field_site_details']); ?>
   </geographicDescription>
   <?php if (!empty($content['field_coordinates'])): ?>
     <boundingCoordinates>

--- a/modules/custom/eml/templates/eml--site-details--site-details.tpl.php
+++ b/modules/custom/eml/templates/eml--site-details--site-details.tpl.php
@@ -1,0 +1,3 @@
+<?php print render($content['field_label']); ?> 
+<?php print render($content['field_description']); ?>
+

--- a/modules/custom/eml/templates/eml--site-details--site-details.tpl.php
+++ b/modules/custom/eml/templates/eml--site-details--site-details.tpl.php
@@ -1,3 +1,3 @@
-<?php print render($content['field_label']); ?> 
+<?php print (render($content['field_label']) . ' : '); ?> 
 <?php print render($content['field_description']); ?>
 

--- a/modules/features/deims_research_site/deims_research_site.features.field.inc
+++ b/modules/features/deims_research_site/deims_research_site.features.field.inc
@@ -553,7 +553,9 @@ function deims_research_site_field_default_fields() {
         'eml' => array(
           'label' => 'above',
           'settings' => array(),
-          'type' => 'hidden',
+          'module' => 'eml',
+          'settings' => array(),
+          'type' => 'entityreference_eml_element',
           'weight' => '3',
         ),
         'full' => array(

--- a/modules/features/deims_site_details/deims_site_details.features.field.inc
+++ b/modules/features/deims_site_details/deims_site_details.features.field.inc
@@ -50,7 +50,7 @@ function deims_site_details_field_default_fields() {
           'label' => 'hidden',
           'module' => 'text',
           'settings' => array(),
-          'type' => 'text_default',
+          'type' => 'text_plain',
           'weight' => '1',
         ),
         'teaser' => array(
@@ -122,7 +122,7 @@ function deims_site_details_field_default_fields() {
           'label' => 'hidden',
           'module' => 'text',
           'settings' => array(),
-          'type' => 'text_default',
+          'type' => 'text_plain',
           'weight' => '0',
         ),
         'teaser' => array(


### PR DESCRIPTION
This branch enhances the EML a bit: it includes the "site details" fields that are embedded in the research site.  it does so appending the site details groups and fields to the 'description' of the content type, and wrapping that all in the <geographicDescription> tag.  Not too important, but good nonetheless. 
