### PR TITLE
Modify eml template so orcid Id is in person's eml

### DIFF
--- a/modules/custom/eml/templates/eml--node--person.tpl.php
+++ b/modules/custom/eml/templates/eml--node--person.tpl.php
@@ -18,3 +18,8 @@
 <?php print render($content['field_fax']); ?>
 <?php print render($content['field_email']); ?>
 <?php print render($content['field_url']); ?>
+<?php $orcid=render($content['field_orcid_id']);
+      $onlineurl_tags = array("<onlineUrl>","</onlineUrl>");
+      $userid_tags = array("<userId directory=\"http://orcid.org\">","</userId>");
+      print str_replace($onlineurl_tags,$userid_tags,$orcid);
+      ?>


### PR DESCRIPTION
Modified the eml--node--person.tpl.php (file in profiles/deims/modules/custom/eml/templates) by adding the following:

<?php $orcid=render($content['field_orcid_id']);
      $onlineurl_tags = array("<onlineUrl>","</onlineUrl>");
      $userid_tags = array("<userId directory=\"http://orcid.org\">","</userId>");
      print str_replace($onlineurl_tags,$userid_tags,$orcid); ?>