### PR TITLE
Issue #154 The second line of a person's address is not added to the …

### DIFF
--- a/modules/custom/eml/eml.field.inc
+++ b/modules/custom/eml/eml.field.inc
@@ -240,6 +240,9 @@ function eml_field_formatter_view($entity_type, $entity, $field, $instance, $lan
         if (!empty($item['thoroughfare'])) {
           $address['deliveryPoint'] = $item['thoroughfare'];
         }
+        if (!empty($item['premise'])) {
+          $address['deliveryPoint'] = $address['deliveryPoint'].", ".$item['premise'];  
+        }        
         if (!empty($item['locality'])) {
           $address['city'] = $item['locality'];
         }


### PR DESCRIPTION
…eml address field

Eml output only the first line of the address stored in the person content. Need to add code in eml module eml.field.inc to check if there is a second line and then concatenated the two, separating them by a comma.